### PR TITLE
lesson28

### DIFF
--- a/lesson28/src/css/style.css
+++ b/lesson28/src/css/style.css
@@ -316,31 +316,27 @@ label {
 }
 
 .register,
-.register-done {
+.register-done,
+.p-password-done {
   padding: 100px 0;
 }
 
-.register-done__inner {
+.register-done__inner,
+.p-password-done__inner {
   background-color: #fff;
   border-radius: 20px;
   width: 70%;
   margin: 0 auto;
   padding: 30px;
+  text-align: center;
+
 }
 
 .register-done__title {
   font-size: 20px;
-  text-align: center;
 }
 
 .register-done__message {
-  text-align: center;
-  margin-top: 10px;
-}
-
-.login-page-link {
-  display: block;
-  text-decoration: underline;
   text-align: center;
   margin-top: 10px;
 }
@@ -354,12 +350,21 @@ label {
   position: relative;
 }
 
-.register-form__item {
+.form-wrapper {
   margin-top: 20px;
 }
 
-.register-form__field {
+.form-item + .form-item{
+  margin-top: 10px;
+}
+
+.form-field {
   margin-top: 5px;
+  position: relative;
+}
+
+.form-foot {
+  margin-top: 10px;
 }
 
 input[type="text"],
@@ -372,21 +377,26 @@ input[type="email"] {
   outline: none;
 }
 
-input[type="password"] {
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="password"]:focus {
+  border: 2px solid skyblue;
+  box-shadow: 0 0 3px skyblue;
+}
+
+
+input[type="password"],
+input[type="text"].password {
+  width: 100%;
+  padding: 10px 35px 10px 10px;
   box-sizing: border-box;
-  padding: 10px;
   border: 2px solid #c2c2c2;
-  width: 50%;
   border-radius: 5px;
   outline: none;
 }
 
-.register-form__foot {
-  margin-top: 30px;
-}
-
 .register-form__submit {
-  margin-top: 30px;
+  margin-top: 20px;
   text-align: center;
 }
 
@@ -461,7 +471,7 @@ button:disabled {
 
 .rules-modal__content > ul,
 .rules-modal__content ol {
-  padding-left: 2em;
+  padding-left: 1em;
   margin-top: 10px;
 }
 
@@ -484,25 +494,19 @@ body.modal-open .rules-modal {
   visibility: visible;
 }
 
-.register-form__field.invalid input {
-  border-color: #ff3860;
-}
-
-.register-form__field.valid input {
-  border-color: #09c372;
-}
-
 .invalid-message {
   color: red;
   font-size: 12px;
   display: block;
 }
 
-.login-page {
+.login-page,
+.register-password {
   padding: 100px 0;
 }
 
-.login-form {
+.login-form,
+.register-password__wrapper {
   background-color: #fff;
   border-radius: 20px;
   width: 70%;
@@ -543,20 +547,8 @@ a.tab-menu__item {
   color: #333;
 }
 
-.login-form__item {
-  margin-top: 20px;
-}
-
-.login-form__field {
-  margin-top: 5px;
-}
-
 .login-form__submit {
-  margin-top: 30px;
-}
-
-.login-page__foot {
-  margin-top: 10px;
+  margin-top: 20px;
 }
 
 .forgot-link {
@@ -569,11 +561,11 @@ a.tab-menu__item {
   opacity: 0.7;
 }
 
-.login-form__field.invalid input {
+.form-field.invalid input {
   border-color: #ff3860;
 }
 
-.login-form__field.valid input {
+.form-field.valid input {
   border-color: #09c372;
 }
 
@@ -589,29 +581,26 @@ a.tab-menu__item {
   padding: 30px;
 }
 
-.forgot-page__title {
+.forgot-page__title,
+.register-password__title {
   font-size: 20px;
 }
 
-.forgot-page__wrapper > .login-page-link {
+.login-page-link {
   color: #333;
+  font-size: 14px;
   text-align: left;
   text-decoration: underline;
 }
 
 .forgot-page__message,
-.forgot-page__form {
+.register-password__message {
   margin-top: 10px;
 }
 
-.forgot-page__submit-button {
-  margin-top: 10px;
-}
-
-.forgot-page__submit-button > button[type="submit"] {
-  padding: 5px;
-  width: 100px;
-  font-size: 16px;
+.forgot-page__submit-button,
+.register-password__submit-button {
+  margin-top: 20px;
 }
 
 .error-page {
@@ -651,6 +640,10 @@ a.tab-menu__item {
 }
 
 .status-message {
+  font-size: 20px;
+}
+
+.notauthorize-title {
   font-size: 20px;
 }
 
@@ -880,18 +873,6 @@ a.tab-menu__item {
   }
 }
 
-.login-form__field {
-  position: relative;
-}
-
-#password {
-  width: 100%;
-}
-
-.password {
-  padding: 10px 35px 10px 10px;
-}
-
 .password-icon {
   width: 25px;
   height: 25px;
@@ -913,3 +894,8 @@ a.tab-menu__item {
 .password-icon.is-show {
   background-image: url(../img/eye-icon.png);
 }
+
+.password-field {
+  width: 70%;
+}
+

--- a/lesson28/src/forgotpassword.html
+++ b/lesson28/src/forgotpassword.html
@@ -17,17 +17,13 @@
       <div class="inner">
         <div class="forgot-page__wrapper">
           <p class="forgot-page__title">パスワードをお忘れの方</p>
-          <p class="forgot-page__message">登録されているメールアドレスを入力してください<br>再設定の手続きを行います</p>
+          <p class="forgot-page__message">メールアドレスを入力してください。<br>再設定の手続きを行います</p>
           <div class="form-wrapper">
             <form id="js-form">
               <dl>
                 <div class="form-item">
                   <dt class="form-title"><label for="email">メールアドレス</label></dt>
                   <dd class="form-field"><input type="email" id="email" placeholder="メールアドレスをご入力ください"></dd>
-                </div>
-                <div class="form-item">
-                  <dt class="form-title"><label for="confirmEmail">確認用</label></dt>
-                  <dd class="form-field"><input type="email" id="confirmEmail" placeholder="確認のため再度ご入力ください"></dd>
                 </div>
                 <div class="forgot-page__submit-button">
                   <button type="submit" id="js-submit-button" disabled>送信</button>

--- a/lesson28/src/forgotpassword.html
+++ b/lesson28/src/forgotpassword.html
@@ -8,6 +8,7 @@
   <title>Document</title>
   <link rel="stylesheet" href="./css/reset.css" />
   <link rel="stylesheet" href="./css/style.css" />
+  <script src="./js/forgotpassword.js" defer></script>
 </head>
 
 <body>
@@ -17,15 +18,26 @@
         <div class="forgot-page__wrapper">
           <p class="forgot-page__title">パスワードをお忘れの方</p>
           <p class="forgot-page__message">登録されているメールアドレスを入力してください<br>再設定の手続きを行います</p>
-          <div class="forgot-page__form">
-            <form>
-              <input type="email" placeholder="機能していません。ダミーです。">
-              <div class="forgot-page__submit-button">
-                <button type="submit" disabled>送信</button>
-              </div>
+          <div class="form-wrapper">
+            <form id="js-form">
+              <dl>
+                <div class="form-item">
+                  <dt class="form-title"><label for="email">メールアドレス</label></dt>
+                  <dd class="form-field"><input type="email" id="email" placeholder="メールアドレスをご入力ください"></dd>
+                </div>
+                <div class="form-item">
+                  <dt class="form-title"><label for="confirmEmail">確認用</label></dt>
+                  <dd class="form-field"><input type="email" id="confirmEmail" placeholder="確認のため再度ご入力ください"></dd>
+                </div>
+                <div class="forgot-page__submit-button">
+                  <button type="submit" id="js-submit-button" disabled>送信</button>
+                </div>
+              </dl>
             </form>
           </div>
-          <a href="./login.html" class="login-page-link">ログインページへ戻る</a>
+          <div class="form-foot">
+            <a href="./login.html" class="login-page-link">ログインページへ戻る</a>
+          </div>
         </div>
       </div>
     </div>

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -60,13 +60,6 @@ const isValidField = (e) => {
   toggleDisableSubmitButton();
 };
 
-const isValidAllField = () => {
-  return Object.keys(constraint).every((key) => {
-    const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
-  });
-}
-
 const toggleDisableSubmitButton = () => {
   const result = Object.keys(constraint).every((key) => {
     const fieldElement = document.getElementById(key).value;

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -75,7 +75,7 @@ confirmEmail.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
   const path = "../register/password.html";
-  const user = JSON.parse(localStorage.getItem("data"));
+  const user = JSON.parse(localStorage.getItem("authInformation"));
   const token = "482r22fafah";
   window.location.href = `${path}?user=${user.username}&token=${token}`;
   e.preventDefault();

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -61,11 +61,11 @@ const isValidField = (e) => {
 };
 
 const toggleDisableSubmitButton = () => {
-  const result = Object.keys(constraint).every((key) => {
+  const isInvalidFields = Object.keys(constraint).some((key) => {
     const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+    return isBlankInInput(fieldElement) || constraint[key].validation();
   });
-  submitButton.disabled = result ? false : true;
+  submitButton.disabled = isInvalidFields;
 };
 
 email.addEventListener("blur", isValidField);

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -1,24 +1,5 @@
 const email = document.getElementById("email");
-const confirmEmail = document.getElementById("confirmEmail");
 const submitButton = document.getElementById("js-submit-button");
-
-const constraint = {
-  email: {
-    validation: () => {
-      const reg = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+\.[A-Za-z]+(\.[A-Za-z]+?)?$/g;
-      return isInvalidRegex(reg, email.value);
-    },
-    invalidMessage: "メールアドレスの形式になっていません"
-  },
-  confirmEmail: {
-    validation: () => {
-      const confirmTrimmedValue = confirmEmail.value.trim();
-      const emailTrimmedValue = email.value.trim();
-      return confirmTrimmedValue !== emailTrimmedValue;
-    },
-    invalidMessage: "入力されたメールアドレスが一致しません"
-  }
-};
 
 const isBlankInInput = (value) => value.trim() === "";
 
@@ -44,39 +25,29 @@ const resetInputField = (e) => {
   errorMessage && errorMessage.remove();
 };
 
-const isValidField = (e) => {
+const emailValidation = (e) => {
   const field = e.target;
+  const reg = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+\.[A-Za-z]+(\.[A-Za-z]+?)?$/g;
   if (isBlankInInput(field.value)) {
     addInvalidMessage(field, "未入力です");
     submitButton.disabled = true;
     return;
   }
-  if (constraint[field.id].validation()) {
-    addInvalidMessage(field, constraint[field.id].invalidMessage);
+  if (isInvalidRegex(reg, field.value)) {
+    addInvalidMessage(field, "メールアドレスの形式になっていません");
     submitButton.disabled = true;
     return;
   }
   addValidClassName(field);
-  toggleDisableSubmitButton();
+  submitButton.disabled = false;
 };
 
-const toggleDisableSubmitButton = () => {
-  const isInvalidFields = Object.keys(constraint).some((key) => {
-    const inputValue = document.getElementById(key).value;
-    return isBlankInInput(inputValue) || constraint[key].validation();
-  });
-  submitButton.disabled = isInvalidFields;
-};
-
-email.addEventListener("blur", isValidField);
+email.addEventListener("blur", emailValidation);
 email.addEventListener("focus", resetInputField);
-confirmEmail.addEventListener("blur", isValidField);
-confirmEmail.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
   e.preventDefault();
   const path = "../register/password.html";
-  const user = JSON.parse(localStorage.getItem("authInformation"));
-  const token = "482r22fafah";
-  window.location.href = `${path}?user=${user.username}&token=${token}`;
+  localStorage.setItem("resetPasswordToken","482r22fafah");
+  window.location.href = `${path}?token=482r22fafah`;
 });

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -74,9 +74,9 @@ confirmEmail.addEventListener("blur", isValidField);
 confirmEmail.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
+  e.preventDefault();
   const path = "../register/password.html";
   const user = JSON.parse(localStorage.getItem("authInformation"));
   const token = "482r22fafah";
   window.location.href = `${path}?user=${user.username}&token=${token}`;
-  e.preventDefault();
 });

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -45,9 +45,15 @@ const emailValidation = (e) => {
 email.addEventListener("blur", emailValidation);
 email.addEventListener("focus", resetInputField);
 
+
 submitButton.addEventListener("click", (e) => {
   e.preventDefault();
-  const path = "../register/password.html";
-  localStorage.setItem("resetPasswordToken","482r22fafah");
-  window.location.href = `${path}?token=482r22fafah`;
+  if(localStorage.getItem("morikenjuku")) {
+    const path = "../register/password.html";
+    localStorage.setItem("resetPasswordToken","482r22fafah");
+    window.location.href = `${path}?token=482r22fafah`;
+  } else {
+    window.location.href = "../notregistereduser.html";
+  }
+
 });

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -75,8 +75,8 @@ confirmEmail.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
   const path = "../register/password.html";
-  const user = localStorage.getItem("username");
+  const user = JSON.parse(localStorage.getItem("data"));
   const token = "482r22fafah";
-  window.location.href = `${path}?user=${user}&token=${token}`;
+  window.location.href = `${path}?user=${user.username}&token=${token}`;
   e.preventDefault();
 });

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -1,0 +1,89 @@
+const email = document.getElementById("email");
+const confirmEmail = document.getElementById("confirmEmail");
+const submitButton = document.getElementById("js-submit-button");
+
+const constraint = {
+  email: {
+    validation: () => {
+      const reg = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+\.[A-Za-z]+(\.[A-Za-z]+?)?$/g;
+      return isInvalidRegex(reg, email.value);
+    },
+    invalidMessage: "メールアドレスの形式になっていません"
+  },
+  confirmEmail: {
+    validation: () => {
+      const confirmTrimmedValue = confirmEmail.value.trim();
+      const emailTrimmedValue = email.value.trim();
+      return confirmTrimmedValue !== emailTrimmedValue;
+    },
+    invalidMessage: "入力されたメールアドレスが一致しません"
+  }
+};
+
+const isBlankInInput = (value) => value.trim() === "";
+
+const isInvalidRegex = (reg, value) => reg.test(value) ? false : true;
+
+const addValidClassName = (target) => {
+  target.parentElement.classList.add("valid");
+};
+
+const addInvalidMessage = (target, message) => {
+  const parent = target.parentElement;
+  parent.classList.add("invalid");
+  const el = document.createElement("span");
+  el.classList.add("invalid-message");
+  el.textContent = message;
+  parent.appendChild(el);
+};
+
+const resetInputField = (e) => {
+  const className = ["invalid", "valid"];
+  e.target.parentElement.classList.remove(...className);
+  const errorMessage = e.target.parentElement.querySelector(".invalid-message");
+  errorMessage && errorMessage.remove();
+};
+
+const isValidField = (e) => {
+  const field = e.target;
+  if (isBlankInInput(field.value)) {
+    addInvalidMessage(field, "未入力です");
+    submitButton.disabled = true;
+    return;
+  }
+  if (constraint[field.id].validation()) {
+    addInvalidMessage(field, constraint[field.id].invalidMessage);
+    submitButton.disabled = true;
+    return;
+  }
+  addValidClassName(field);
+  toggleDisableSubmitButton();
+};
+
+const isValidAllField = () => {
+  return Object.keys(constraint).every((key) => {
+    const fieldElement = document.getElementById(key).value;
+    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+  });
+}
+
+const toggleDisableSubmitButton = () => {
+  const result = Object.keys(constraint).every((key) => {
+    const fieldElement = document.getElementById(key).value;
+    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+  });
+  submitButton.disabled = result ? false : true;
+};
+
+email.addEventListener("blur", isValidField);
+email.addEventListener("focus", resetInputField);
+confirmEmail.addEventListener("blur", isValidField);
+confirmEmail.addEventListener("focus", resetInputField);
+
+submitButton.addEventListener("click", (e) => {
+  const path = "../register/password.html";
+  const user = localStorage.getItem("username");
+  const token = "482r22fafah";
+  window.location.href = `${path}?user=${user}&token=${token}`;
+  e.preventDefault();
+});

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -22,7 +22,7 @@ const constraint = {
 
 const isBlankInInput = (value) => value.trim() === "";
 
-const isInvalidRegex = (reg, value) => reg.test(value) ? false : true;
+const isInvalidRegex = (reg, value) => !reg.test(value);
 
 const addValidClassName = (target) => {
   target.parentElement.classList.add("valid");

--- a/lesson28/src/js/forgotpassword.js
+++ b/lesson28/src/js/forgotpassword.js
@@ -62,8 +62,8 @@ const isValidField = (e) => {
 
 const toggleDisableSubmitButton = () => {
   const isInvalidFields = Object.keys(constraint).some((key) => {
-    const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation();
+    const inputValue = document.getElementById(key).value;
+    return isBlankInInput(inputValue) || constraint[key].validation();
   });
   submitButton.disabled = isInvalidFields;
 };

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -101,15 +101,15 @@ loginButton.addEventListener("click", (e) => {
   init(inputValues);
 });
 
-const checkUsername = (value,data) => value === data.username;
+const checkUsername = (value, data) => value === data.username;
 
-const checkPassword = (value,data) => value === data.password;
+const checkPassword = (value, data) => value === data.password;
 
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
     const { username, password } = inputData;
-    const userData = JSON.parse(localStorage.getItem("data"));
-    if (checkUsername(username,userData) && checkPassword(password,userData)) {
+    const userData = JSON.parse(localStorage.getItem("authInformation"));
+    if (checkUsername(username, userData) && checkPassword(password, userData)) {
       resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 });

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -101,14 +101,15 @@ loginButton.addEventListener("click", (e) => {
   init(inputValues);
 });
 
-const checkUsername = (value) => value === localStorage.getItem("username");
+const checkUsername = (value,data) => value === data.username;
 
-const checkPassword = (value) => value === localStorage.getItem("password");
+const checkPassword = (value,data) => value === data.password;
 
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
     const { username, password } = inputData;
-    if (checkUsername(username) && checkPassword(password)) {
+    const userData = JSON.parse(localStorage.getItem("data"));
+    if (checkUsername(username,userData) && checkPassword(password,userData)) {
       resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 });

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -101,15 +101,14 @@ loginButton.addEventListener("click", (e) => {
   init(inputValues);
 });
 
-const checkUsername = (inputValue, data) => inputValue === data.username;
+const checkUsername = (value) => value === localStorage.getItem("username");
 
-const checkPassword = (inputValue, data) => inputValue === data.password;
+const checkPassword = (value) => value === localStorage.getItem("password");
 
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
-    const userData = { username: "yamadahanako", password: "N302aoe3" };
     const { username, password } = inputData;
-    if (checkUsername(username, userData) && checkPassword(password, userData)) {
+    if (checkUsername(username) && checkPassword(password)) {
       resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 });

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -7,11 +7,8 @@ if (localStorage.getItem("token")) window.location.href = "./index.html";
 
 const constraint = {
   username: {
-    validation: () => {
-      const limitNumber = 16;
-      return isLimitTextLength(userName.value, limitNumber);
-    },
-    invalidMessage: "ユーザー名は15文字以下にしてください。"
+    validation: () => isBlankInInput(userName.value),
+    invalidMessage: "未入力です"
   },
   password: {
     validation: () => {
@@ -24,8 +21,6 @@ const constraint = {
 
 const isBlankInInput = (value) => value.trim() === "";
 
-const isLimitTextLength = (value, limit) => value.length >= limit;
-
 const isInvalidRegex = (reg, value) => !reg.test(value);
 
 const addValidClassName = (target) => {
@@ -34,11 +29,6 @@ const addValidClassName = (target) => {
 
 const isValidField = (e) => {
   const field = e.target;
-  if (isBlankInInput(field.value)) {
-    addInvalidMessage(field, "未入力です");
-    loginButton.disabled = true;
-    return;
-  }
   if (constraint[field.id].validation()) {
     addInvalidMessage(field, constraint[field.id].invalidMessage);
     loginButton.disabled = true;
@@ -51,8 +41,7 @@ const isValidField = (e) => {
 
 const toggleDisableLoginButton = () => {
   const isInvalidFields = Object.keys(constraint).some((key) => {
-    const inputValue = document.getElementById(key).value;
-    return isBlankInInput(inputValue) || constraint[key].validation();
+    return constraint[key].validation();
   });
   loginButton.disabled = isInvalidFields;
 };
@@ -101,15 +90,15 @@ loginButton.addEventListener("click", (e) => {
   init(inputValues);
 });
 
-const checkUsername = (value, data) => value === data.username;
+const isMatchUsernameOrEmail = (value, data) => value === data.username || data.email;
 
-const checkPassword = (value, data) => value === data.password;
+const isMatchPassword = (value, data) => value === data.password;
 
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
     const { username, password } = inputData;
     const userData = JSON.parse(localStorage.getItem("morikenjuku"));
-    if (checkUsername(username, userData) && checkPassword(password, userData)) {
+    if (isMatchUsernameOrEmail(username, userData) && isMatchPassword(password, userData)) {
       resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 });

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -108,7 +108,7 @@ const checkPassword = (value, data) => value === data.password;
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
     const { username, password } = inputData;
-    const userData = JSON.parse(localStorage.getItem("authInformation"));
+    const userData = JSON.parse(localStorage.getItem("morikenjuku"));
     if (checkUsername(username, userData) && checkPassword(password, userData)) {
       resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
     } else {

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -26,7 +26,7 @@ const isBlankInInput = (value) => value.trim() === "";
 
 const isLimitTextLength = (value, limit) => value.length >= limit;
 
-const isInvalidRegex = (reg, value) => reg.test(value) ? false : true;
+const isInvalidRegex = (reg, value) => !reg.test(value);
 
 const addValidClassName = (target) => {
   target.parentElement.classList.add("valid");;

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -51,8 +51,8 @@ const isValidField = (e) => {
 
 const toggleDisableLoginButton = () => {
   const isInvalidFields = Object.keys(constraint).some((key) => {
-    const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation();
+    const inputValue = document.getElementById(key).value;
+    return isBlankInInput(inputValue) || constraint[key].validation();
   });
   loginButton.disabled = isInvalidFields;
 };

--- a/lesson28/src/js/login.js
+++ b/lesson28/src/js/login.js
@@ -50,11 +50,11 @@ const isValidField = (e) => {
 };
 
 const toggleDisableLoginButton = () => {
-  const result = Object.keys(constraint).every((key) => {
+  const isInvalidFields = Object.keys(constraint).some((key) => {
     const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+    return isBlankInInput(fieldElement) || constraint[key].validation();
   });
-  loginButton.disabled = result ? false : true;
+  loginButton.disabled = isInvalidFields;
 };
 
 const addInvalidMessage = (target, message) => {

--- a/lesson28/src/js/password-done.js
+++ b/lesson28/src/js/password-done.js
@@ -1,6 +1,6 @@
 const checkUrlParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  const token = localStorage.getItem("updatePasswordToken");
+  const token = localStorage.getItem("forgotPasswordDoneToken");
   if (urlParams.get("token") === token) {
     window.location.href = "../register/password-done.html";
   } else {

--- a/lesson28/src/js/password-done.js
+++ b/lesson28/src/js/password-done.js
@@ -1,0 +1,1 @@
+setTimeout(() => window.location.href = "../index.html", 3000)

--- a/lesson28/src/js/password-done.js
+++ b/lesson28/src/js/password-done.js
@@ -1,1 +1,12 @@
-setTimeout(() => window.location.href = "../login.html", 3000)
+const checkUrlParams = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const token = localStorage.getItem("updatePasswordToken");
+  if (urlParams.get("token") === token) {
+    window.location.href = "../register/password-done.html";
+  } else {
+    window.location.href = "../notauthorize.html";
+  }
+}
+
+window.location.search && checkUrlParams();
+setTimeout(() => window.location.href = "../login.html", 3000);

--- a/lesson28/src/js/password-done.js
+++ b/lesson28/src/js/password-done.js
@@ -1,1 +1,1 @@
-setTimeout(() => window.location.href = "../index.html", 3000)
+setTimeout(() => window.location.href = "../login.html", 3000)

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -85,15 +85,11 @@ const togglePasswordButton = (e) => {
 }
 
 const isTokenParam = (params) => {
-  const tokenParam = params.get("token");
   const token = "482r22fafah";
-  return tokenParam === token;
+  return params.get("token") === token;
 }
 
-const isUserParma = (params, data) => {
-  const userParam = params.get("user");
-  return userParam === data.username;
-}
+const isUserParma = (params, data) => params.get("user") === data.username;
 
 const checkUrlParams = () => {
   const urlParams = new URLSearchParams(window.location.search);

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -90,14 +90,15 @@ const isTokenParam = (params) => {
   return tokenParam === token;
 }
 
-const isUserParma = (params) => {
+const isUserParma = (params, data) => {
   const userParam = params.get("user");
-  return userParam === localStorage.username;
+  return userParam === data.username;
 }
 
 const checkUrlParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  if (isTokenParam(urlParams) && isUserParma(urlParams)) {
+  const userData = JSON.parse(localStorage.getItem("data"));
+  if (isTokenParam(urlParams) && isUserParma(urlParams, userData)) {
     window.location.href = "../register/password.html";
   } else {
     window.location.href = "../notauthorize.html";
@@ -116,7 +117,9 @@ confirmPassword.addEventListener("focus", resetInputField);
 
 
 submitButton.addEventListener("click", (e) => {
-  localStorage.setItem("password", password.value);
+  const userData = JSON.parse(localStorage.data);
+  userData.password = password.value;
+  localStorage.setItem("data", JSON.stringify(userData));
   window.location.href = "./password-done.html";
   e.preventDefault();
 });

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -4,6 +4,14 @@ const password = document.getElementById("password");
 const submitButton = document.getElementById("js-submit-button");
 const confirmPassword = document.getElementById("confirmPassword");
 
+submitButton.addEventListener("click", (e) => {
+  const userData = JSON.parse(localStorage.data);
+  userData.password = password.value;
+  localStorage.setItem("data", JSON.stringify(userData));
+  window.location.href = "./password-done.html";
+  e.preventDefault();
+});
+
 const constraint = {
   password: {
     validation: () => {
@@ -111,14 +119,6 @@ password.addEventListener("focus", resetInputField);
 confirmPassword.addEventListener("blur", isValidField);
 confirmPassword.addEventListener("focus", resetInputField);
 
-
-submitButton.addEventListener("click", (e) => {
-  const userData = JSON.parse(localStorage.data);
-  userData.password = password.value;
-  localStorage.setItem("data", JSON.stringify(userData));
-  window.location.href = "./password-done.html";
-  e.preventDefault();
-});
 
 
 

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -84,17 +84,10 @@ const togglePasswordButton = (e) => {
   }
 }
 
-const isTokenParam = (params) => {
-  const token = "482r22fafah";
-  return params.get("token") === token;
-}
-
-const isUserParma = (params, data) => params.get("user") === data.username;
-
 const checkUrlParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  const userData = JSON.parse(localStorage.getItem("authInformation"));
-  if (isTokenParam(urlParams) && isUserParma(urlParams, userData)) {
+  const token = localStorage.getItem("resetPasswordToken");
+  if (urlParams.get("token") === token) {
     window.location.href = "../register/password.html";
   } else {
     window.location.href = "../notauthorize.html";
@@ -111,12 +104,19 @@ password.addEventListener("focus", resetInputField);
 confirmPassword.addEventListener("blur", isValidField);
 confirmPassword.addEventListener("focus", resetInputField);
 
-submitButton.addEventListener("click", (e) => {
-  e.preventDefault();
+const changeUserPasswordInStorage = () => {
   const userData = JSON.parse(localStorage.authInformation);
   userData.password = password.value;
   localStorage.setItem("authInformation", JSON.stringify(userData));
-  window.location.href = "./password-done.html";
+}
+
+submitButton.addEventListener("click", (e) => {
+  e.preventDefault();
+  changeUserPasswordInStorage();
+  localStorage.removeItem("resetPasswordToken");
+  localStorage.setItem("updatePasswordToken", "hoge123aaaa");
+  const path = "./password-done.html";
+  window.location.href = `${path}?token=hoge123aaaa`;
 });
 
 

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -4,14 +4,6 @@ const password = document.getElementById("password");
 const submitButton = document.getElementById("js-submit-button");
 const confirmPassword = document.getElementById("confirmPassword");
 
-submitButton.addEventListener("click", (e) => {
-  const userData = JSON.parse(localStorage.authInformation);
-  userData.password = password.value;
-  localStorage.setItem("authInformation", JSON.stringify(userData));
-  window.location.href = "./password-done.html";
-  e.preventDefault();
-});
-
 const constraint = {
   password: {
     validation: () => {
@@ -119,6 +111,13 @@ password.addEventListener("focus", resetInputField);
 confirmPassword.addEventListener("blur", isValidField);
 confirmPassword.addEventListener("focus", resetInputField);
 
+submitButton.addEventListener("click", (e) => {
+  e.preventDefault();
+  const userData = JSON.parse(localStorage.authInformation);
+  userData.password = password.value;
+  localStorage.setItem("authInformation", JSON.stringify(userData));
+  window.location.href = "./password-done.html";
+});
 
 
 

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -114,7 +114,7 @@ submitButton.addEventListener("click", (e) => {
   e.preventDefault();
   changeUserPasswordInStorage();
   localStorage.removeItem("resetPasswordToken");
-  localStorage.setItem("updatePasswordToken", "hoge123aaaa");
+  localStorage.setItem("forgotPasswordDoneToken", "hoge123aaaa");
   const path = "./password-done.html";
   window.location.href = `${path}?token=hoge123aaaa`;
 });

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -72,11 +72,11 @@ const resetInputField = (e) => {
 };
 
 const toggleDisableSubmitButton = () => {
-  const result = Object.keys(constraint).every((key) => {
+  const isInvalidFields = Object.keys(constraint).every((key) => {
     const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+    return isBlankInInput(fieldElement) || constraint[key].validation();
   });
-  submitButton.disabled = result ? false : true;
+  submitButton.disabled = isInvalidFields;
 };
 
 const togglePasswordButton = (e) => {

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -72,7 +72,7 @@ const resetInputField = (e) => {
 };
 
 const toggleDisableSubmitButton = () => {
-  const isInvalidFields = Object.keys(constraint).every((key) => {
+  const isInvalidFields = Object.keys(constraint).some((key) => {
     const fieldElement = document.getElementById(key).value;
     return isBlankInInput(fieldElement) || constraint[key].validation();
   });

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -24,7 +24,7 @@ const constraint = {
 
 const isBlankInInput = (value) => value.trim() === "";
 
-const isInvalidRegex = (reg, value) => reg.test(value) ? false : true;
+const isInvalidRegex = (reg, value) => !reg.test(value);
 
 const addValidClassName = (target) => {
   target.parentElement.classList.add("valid");

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -73,8 +73,8 @@ const resetInputField = (e) => {
 
 const toggleDisableSubmitButton = () => {
   const isInvalidFields = Object.keys(constraint).some((key) => {
-    const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation();
+    const inputValue = document.getElementById(key).value;
+    return isBlankInInput(inputValue) || constraint[key].validation();
   });
   submitButton.disabled = isInvalidFields;
 };

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -1,0 +1,128 @@
+
+const passwordButtons = [...document.querySelectorAll(".js-password-icon")];
+const password = document.getElementById("password");
+const submitButton = document.getElementById("js-submit-button");
+const confirmPassword = document.getElementById("confirmPassword");
+
+const constraint = {
+  password: {
+    validation: () => {
+      const reg = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/g;
+      return isInvalidRegex(reg, password.value);
+    },
+    invalidMessage: "8文字以上の大小の英数字を交ぜたものにしてください。"
+  },
+  confirmPassword: {
+    validation: () => {
+      const confirmTrimmedValue = confirmPassword.value.trim();
+      const passwordTrimmedValue = password.value.trim();
+      return confirmTrimmedValue !== passwordTrimmedValue
+    },
+    invalidMessage: "入力されたパスワードが一致してません"
+  }
+};
+
+const isBlankInInput = (value) => value.trim() === "";
+
+const isInvalidRegex = (reg, value) => reg.test(value) ? false : true;
+
+const addValidClassName = (target) => {
+  target.parentElement.classList.add("valid");
+};
+
+const isValidField = (e) => {
+  const field = e.target;
+  if (isBlankInInput(field.value)) {
+    addInvalidMessage(field, "未入力です");
+    submitButton.disabled = true;
+    return;
+  }
+  if (constraint[field.id].validation()) {
+    addInvalidMessage(field, constraint[field.id].invalidMessage);
+    submitButton.disabled = true;
+    return;
+  }
+
+  addValidClassName(field);
+  toggleDisableSubmitButton();
+};
+
+const addInvalidMessage = (target, message) => {
+  const parent = target.parentElement;
+  parent.classList.add("invalid");
+  const el = document.createElement("span");
+  el.classList.add("invalid-message");
+  el.textContent = message;
+  parent.appendChild(el);
+};
+
+const resetInputField = (e) => {
+  const className = ["invalid", "valid"];
+  e.target.parentElement.classList.remove(...className);
+  const errorMessage = e.target.parentElement.querySelector(".invalid-message");
+  errorMessage && errorMessage.remove();
+};
+
+const toggleDisableSubmitButton = () => {
+  const result = Object.keys(constraint).every((key) => {
+    const fieldElement = document.getElementById(key).value;
+    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+  });
+  submitButton.disabled = result ? false : true;
+};
+
+const togglePasswordButton = (e) => {
+  const target = e.target;
+  if (target.classList.contains("is-hide")) {
+    target.previousElementSibling.type = "text";
+    target.classList.remove("is-hide");
+    target.classList.add("is-show");
+  } else {
+    target.previousElementSibling.type = "password";
+    target.classList.remove("is-show");
+    target.classList.add("is-hide");
+  }
+}
+
+const isTokenParam = (params) => {
+  const tokenParam = params.get("token");
+  const token = "482r22fafah";
+  return tokenParam === token;
+}
+
+const isUserParma = (params) => {
+  const userParam = params.get("user");
+  return userParam === localStorage.username;
+}
+
+const checkUrlParams = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  if (isTokenParam(urlParams) && isUserParma(urlParams)) {
+    window.location.href = "../register/password.html";
+  } else {
+    window.location.href = "../notauthorize.html";
+  }
+}
+
+window.location.search && checkUrlParams();
+
+passwordButtons.forEach(button => {
+  button.addEventListener("click", togglePasswordButton);
+});
+password.addEventListener("blur", isValidField);
+password.addEventListener("focus", resetInputField);
+confirmPassword.addEventListener("blur", isValidField);
+confirmPassword.addEventListener("focus", resetInputField);
+
+
+submitButton.addEventListener("click", (e) => {
+  localStorage.setItem("password", password.value);
+  window.location.href = "./password-done.html";
+  e.preventDefault();
+});
+
+
+
+
+
+

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -105,9 +105,9 @@ confirmPassword.addEventListener("blur", isValidField);
 confirmPassword.addEventListener("focus", resetInputField);
 
 const changeUserPasswordInStorage = () => {
-  const userData = JSON.parse(localStorage.authInformation);
+  const userData = JSON.parse(localStorage.morikenjuku);
   userData.password = password.value;
-  localStorage.setItem("authInformation", JSON.stringify(userData));
+  localStorage.setItem("morikenjuku", JSON.stringify(userData));
 }
 
 submitButton.addEventListener("click", (e) => {

--- a/lesson28/src/js/password.js
+++ b/lesson28/src/js/password.js
@@ -5,9 +5,9 @@ const submitButton = document.getElementById("js-submit-button");
 const confirmPassword = document.getElementById("confirmPassword");
 
 submitButton.addEventListener("click", (e) => {
-  const userData = JSON.parse(localStorage.data);
+  const userData = JSON.parse(localStorage.authInformation);
   userData.password = password.value;
-  localStorage.setItem("data", JSON.stringify(userData));
+  localStorage.setItem("authInformation", JSON.stringify(userData));
   window.location.href = "./password-done.html";
   e.preventDefault();
 });
@@ -101,7 +101,7 @@ const isUserParma = (params, data) => params.get("user") === data.username;
 
 const checkUrlParams = () => {
   const urlParams = new URLSearchParams(window.location.search);
-  const userData = JSON.parse(localStorage.getItem("data"));
+  const userData = JSON.parse(localStorage.getItem("authInformation"));
   if (isTokenParam(urlParams) && isUserParma(urlParams, userData)) {
     window.location.href = "../register/password.html";
   } else {

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -104,8 +104,8 @@ const resetInputField = (e) => {
 
 const toggleDisableSubmitButton = () => {
   const isInvalidFields = Object.keys(constraint).some((key) => {
-    const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation() || !checkBox.checked;
+    const inputValue = document.getElementById(key).value;
+    return isBlankInInput(inputValue) || constraint[key].validation() || !checkBox.checked;
   });
   submitButton.disabled = isInvalidFields;
 };

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -133,6 +133,6 @@ email.addEventListener("focus", resetInputField);
 password.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", () => {
-  const inputValues = { username: userName.value, password: password.value };
+  const inputValues = { username: userName.value, password: password.value, email: email.value };
   localStorage.setItem("morikenjuku",JSON.stringify(inputValues));
 });

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -132,7 +132,7 @@ userName.addEventListener("focus", resetInputField);
 email.addEventListener("focus", resetInputField);
 password.addEventListener("focus", resetInputField);
 
-submitButton.addEventListener("click",() => {
-  localStorage.setItem("username",userName.value);
-  localStorage.setItem("password",password.value);
+submitButton.addEventListener("click", () => {
+  const userData = { username: userName.value, password: password.value };
+  localStorage.setItem("data",JSON.stringify(userData));
 });

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -63,7 +63,7 @@ const isBlankInInput = (value) => value.trim() === "";
 
 const isLimitTextLength = (value, limit) => value.length >= limit;
 
-const isInvalidRegex = (reg, value) => reg.test(value) ? false : true;
+const isInvalidRegex = (reg, value) => !reg.test(value);
 
 const addValidClassName = (target) => {
   target.parentElement.classList.add("valid");

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -132,3 +132,7 @@ userName.addEventListener("focus", resetInputField);
 email.addEventListener("focus", resetInputField);
 password.addEventListener("focus", resetInputField);
 
+submitButton.addEventListener("click",() => {
+  localStorage.setItem("username",userName.value);
+  localStorage.setItem("password",password.value);
+});

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -133,6 +133,6 @@ email.addEventListener("focus", resetInputField);
 password.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", () => {
-  const userData = { username: userName.value, password: password.value };
-  localStorage.setItem("data",JSON.stringify(userData));
+  const inputValues = { username: userName.value, password: password.value };
+  localStorage.setItem("authInformation",JSON.stringify(inputValues));
 });

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -134,5 +134,5 @@ password.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", () => {
   const inputValues = { username: userName.value, password: password.value };
-  localStorage.setItem("authInformation",JSON.stringify(inputValues));
+  localStorage.setItem("morikenjuku",JSON.stringify(inputValues));
 });

--- a/lesson28/src/js/register.js
+++ b/lesson28/src/js/register.js
@@ -103,11 +103,11 @@ const resetInputField = (e) => {
 };
 
 const toggleDisableSubmitButton = () => {
-  const result = Object.keys(constraint).every((key) => {
+  const isInvalidFields = Object.keys(constraint).some((key) => {
     const fieldElement = document.getElementById(key).value;
-    return isBlankInInput(fieldElement) || constraint[key].validation() ? false : true;
+    return isBlankInInput(fieldElement) || constraint[key].validation() || !checkBox.checked;
   });
-  submitButton.disabled = result && checkBox.checked ? false : true;
+  submitButton.disabled = isInvalidFields;
 };
 
 const togglePasswordButton = (e) => {

--- a/lesson28/src/login.html
+++ b/lesson28/src/login.html
@@ -25,10 +25,10 @@
               <dl>
                 <div class="form-item">
                   <dt class="form-title">
-                    <label for="username">ユーザー名</label>
+                    <label for="username">ユーザー名、またはメールアドレス</label>
                   </dt>
                   <dd class="form-field">
-                    <input type="text" id="username" placeholder="ユーザー名" required>
+                    <input type="text" id="username" placeholder="username or Email" required>
                   </dd>
                 </div>
                 <div class="form-item">

--- a/lesson28/src/notauthorize.html
+++ b/lesson28/src/notauthorize.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <link rel="stylesheet" href="./css/reset.css">
+  <link rel="stylesheet" href="./css/style.css">
+</head>
+
+<body>
+  <main>
+    <div class="error-page">
+      <div class="error-page__inner">
+        <p class="notauthorize-title">権限がありません</p>
+        <p class="notauthorize-en-title">Not Authorize</p>
+        <a href="./login.html" class="login-link">ログインページへ</a>
+      </div>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/lesson28/src/notregistereduser.html
+++ b/lesson28/src/notregistereduser.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+</head>
+<body>
+  <p>会員登録が確認できませんでした。</p>
+  <a href="./register.html">会員登録へ</a>
+</body>
+</html>

--- a/lesson28/src/register/password-done.html
+++ b/lesson28/src/register/password-done.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <link rel="stylesheet" href="../css/reset.css">
+  <link rel="stylesheet" href="../css/style.css">
+  <script src="../js/password-done.js"></script>
+</head>
+
+<body>
+  <main>
+    <div class="p-password-done">
+      <div class="p-password-done__inner">
+        <p class="p-password-done__title">パスワードが再登録されました</p>
+        <p class="p-password-done__text">このページは3秒後に自動でログインページへ移ります<br>自動で移らない場合は下記リンクをクリックしてください</p>
+        <a href="../login.html" class="login-page-link">ログインページへ</a>
+      </div>
+    </div>
+  </main>
+  <script>
+
+  </script>
+</body>
+
+</html>

--- a/lesson28/src/register/password.html
+++ b/lesson28/src/register/password.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <link rel="stylesheet" href="../css/reset.css" />
+  <link rel="stylesheet" href="../css/style.css" />
+  <script src="../js/password.js" defer></script>
+</head>
+
+<body>
+  <main>
+    <div class="register-password">
+      <div class="inner">
+        <div class="register-password__wrapper">
+          <p class="register-password__title">パスワードの再設定</p>
+          <p class="register-password__message">新たに登録するパスワードを入力してください</p>
+          <div class="form-wrapper">
+            <form>
+              <dl>
+                <div class="form-item">
+                  <dt class="form-title"><label for="password">新しいパスワード</label></dt>
+                  <dd class="form-field password-field">
+                    <input type="password" id="password" placeholder="新たに登録するパスワード">
+                    <button class="password-icon is-hide js-password-icon" type="button"></button>
+                  </dd>
+                </div>
+                <div class="form-item">
+                  <dt class="form-title"><label for="confirmPassword">確認用</label></dt>
+                  <dd class="form-field password-field">
+                    <input type="password" id="confirmPassword" placeholder="確認のため再度ご入力ください">
+                    <button class="password-icon is-hide js-password-icon" type="button"></button>
+                  </dd>
+                </div>
+                <div class="register-password__submit-button">
+                  <button type="submit" id="js-submit-button" disabled>登録</button>
+                </div>
+              </dl>
+            </form>
+          </div>
+          <div class="form-foot">
+            <a href="../login.html" class="login-page-link">ログインページへ</a>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </main>
+</body>
+
+</html>


### PR DESCRIPTION
# [Lesson28](https://github.com/kenmori/handsonFrontend/blob/feature/find2/work/markup/1.md#%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89%E5%BF%98%E3%82%8C%E3%81%9F%E6%96%B9%E3%81%B8%E3%83%9A%E3%83%BC%E3%82%B8)

``` text
パスワード忘れた方へ(forgetpassword.html)のページを作ってください

上記で作ったメールアドレスを入力するところがあります
確認のためのメールアドレス入力欄があります
2つのメールアドレスのinput値があっていれば送信ボタンが押せます

通常のアプリの流れは 送信ボタン押下してたらこの後メールアドレス先にメールが飛んできて、
そのメール本文には以下のようなリンクが埋め込まれていて、
そこを踏んだら再登録画面に行けます 
そのリンクには制限時間が設けてあり、「3時間以内に訪れてください」とかがあります 
それを踏むとサーバーはそのリンクがどのユーザーに対して発行したのかを検証して
問題なければ画面を表示します 
それが register/password.html こちらの再登録画面です

そこには 新しいパスワード:のinputがあり 確認のために再度パスワード入力するinputもあります
バリデーションは前に作ったものと一緒です

今回はメールが飛ばないので、forgetpassword.html内で送信を押したら
register/password.htmlへ飛ばしてください 
その際のリンクはregister/password.html?user=fafaefafein092fnaof&token=482r22fafah 
みたいなurlにして(userとtokenの値は固定値) urlパラメータのuserが
以前ご自身で決めたそのログインユーザーかどうか固定値のそれと照らし合わせて確認、
tokenは482r22fafahかどうかを確認します

もしtokenやuserが間違っていたら notautherize.html 権限がありませんページに飛ばしてください
userはローカルストレージにあるそれと同じかどうか検証して違った場合 notautherize.htmlへ

2つのurlパラメータがあっている場合に
register/password.htmlを表示します

表示は上記の通りで
okなら適当なパスワードを再発行して ローカルストレージに埋め込みor変更してください
その後はそのパスワードでログインができるようにします
```
## [CodeSandBox](https://codesandbox.io/s/js-lesson28-6c7mg8?file=/js/forgotpassword.js) / Latest commit : 774cb13

※ 仕様に対してどのように実装したかがわかる様にコメントで示しています。ご確認下さい。

--- 

✅ 会員登録ページで登録されたuser名と、パスワードをlocalstorageにセットする
https://github.com/sae-github/JS_lesson/pull/32#discussion_r808637337

✅ ログインの認証方法をlocalstorage内の値と検証する方法へ変更
https://github.com/sae-github/JS_lesson/pull/32#discussion_r808659708

✅ forgotpassword.htmlでメールアドレスを入力・送信後の遷移先パラメーター部分の実装
https://github.com/sae-github/JS_lesson/pull/32#discussion_r808635773

✅  URLパラメータ の検証
tokenとuserをそれぞれ検証する
https://github.com/sae-github/JS_lesson/pull/32#discussion_r808637913