### PR TITLE
feat: allow multiple members to register

### DIFF
--- a/lesson29/.gitignore
+++ b/lesson29/.gitignore
@@ -6,5 +6,6 @@ package-lock.json
 package.json
 *.local
 vite.config.js
+chance.min.js
 
 

--- a/lesson29/.gitignore
+++ b/lesson29/.gitignore
@@ -6,6 +6,5 @@ package-lock.json
 package.json
 *.local
 vite.config.js
-chance.min.js
 
 

--- a/lesson29/src/js/login.js
+++ b/lesson29/src/js/login.js
@@ -7,7 +7,7 @@ if (localStorage.getItem("token")) window.location.href = "./index.html";
 
 const constraint = {
   username: {
-    validation: () => isBlankInInput(userName.value),
+    validation: () => isBlankInInput(userField.value),
     invalidMessage: "未入力です"
   },
   password: {
@@ -90,26 +90,31 @@ loginButton.addEventListener("click", (e) => {
   init(inputValues);
 });
 
-const isMatchUsernameOrEmail = (value, { email, username }) => {
-  return value === username || value === email;
-}
+const isMatchUsernameOrEmail = ({ username, email }, inputValue) => {
+  return username === inputValue || email === inputValue;
+};
 
-const isMatchPassword = (data, { password }) => data === password;
+const isMatchPassword = ({ password }, inputPassword) => password === inputPassword;
+
+const findLoginUser = (usersData, { username, password }) => {
+  return Object.values(usersData).find((data) => {
+    return (
+      isMatchUsernameOrEmail(data, username) && isMatchPassword(data, password)
+    );
+  });
+};
 
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
-    const { username: inputUserName, password: inputPassword } = inputData;
     const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
-    const userCheckedResult = Object.values(usersData).some((data) => {
-      return isMatchUsernameOrEmail(inputUserName, data) && isMatchPassword(inputPassword, data);
-    });
-    if (userCheckedResult) {
-      resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
+    const foundLoginUser = findLoginUser(usersData, inputData);
+    if (foundLoginUser) {
+      resolve({ token: foundLoginUser.token, ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 });
     }
-  })
-}
+  });
+};
 
 const getToken = async (inputData) => {
   try {

--- a/lesson29/src/js/login.js
+++ b/lesson29/src/js/login.js
@@ -3,8 +3,6 @@ const passwordField = document.getElementById("password");
 const loginButton = document.getElementById("js-login-button");
 const passwordButton = document.getElementById("js-password-icon");
 
-if (localStorage.getItem("token")) window.location.href = "./index.html";
-
 const constraint = {
   username: {
     validation: () => isBlankInInput(userField.value),

--- a/lesson29/src/js/login.js
+++ b/lesson29/src/js/login.js
@@ -1,5 +1,5 @@
-const userName = document.getElementById("username");
-const password = document.getElementById("password");
+const userField = document.getElementById("username");
+const passwordField = document.getElementById("password");
 const loginButton = document.getElementById("js-login-button");
 const passwordButton = document.getElementById("js-password-icon");
 
@@ -13,7 +13,7 @@ const constraint = {
   password: {
     validation: () => {
       const reg = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/g;
-      return isInvalidRegex(reg, password.value);
+      return isInvalidRegex(reg, passwordField.value);
     },
     invalidMessage: "8文字以上の大小の英数字を交ぜたものにしてください。"
   }
@@ -65,27 +65,27 @@ const resetInputField = (e) => {
 const togglePasswordButton = (e) => {
   const target = e.target;
   if (target.classList.contains("is-hide")) {
-    password.type = "text";
+    passwordField.type = "text";
     target.classList.remove("is-hide");
     target.classList.add("is-show");
   } else {
-    password.type = "password";
+    passwordField.type = "password";
     target.classList.remove("is-show");
     target.classList.add("is-hide");
   }
 }
 
 passwordButton.addEventListener("click", togglePasswordButton);
-password.addEventListener("blur", isValidField);
-userName.addEventListener("blur", isValidField);
-userName.addEventListener("focus", resetInputField);
-password.addEventListener("focus", resetInputField);
+passwordField.addEventListener("blur", isValidField);
+userField.addEventListener("blur", isValidField);
+userField.addEventListener("focus", resetInputField);
+passwordField.addEventListener("focus", resetInputField);
 
 loginButton.addEventListener("click", (e) => {
   e.preventDefault();
   const inputValues = {
-    username: userName.value,
-    password: password.value
+    username: userField.value,
+    password: passwordField.value
   }
   init(inputValues);
 });

--- a/lesson29/src/js/login.js
+++ b/lesson29/src/js/login.js
@@ -90,17 +90,20 @@ loginButton.addEventListener("click", (e) => {
   init(inputValues);
 });
 
-const isMatchUsernameOrEmail = (value, data) => {
-  return value === data.username || value === data.email;
+const isMatchUsernameOrEmail = (value, { email, username }) => {
+  return value === username || value === email;
 }
 
-const isMatchPassword = (value, data) => value === data.password;
+const isMatchPassword = (data, { password }) => data === password;
 
 const checkUserData = (inputData) => {
   return new Promise((resolve, reject) => {
-    const { username, password } = inputData;
-    const userData = JSON.parse(localStorage.getItem("morikenjuku"));
-    if (isMatchUsernameOrEmail(username, userData) && isMatchPassword(password, userData)) {
+    const { username: inputUserName, password: inputPassword } = inputData;
+    const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
+    const userCheckedResult = Object.values(usersData).some((data) => {
+      return isMatchUsernameOrEmail(inputUserName, data) && isMatchPassword(inputPassword, data);
+    });
+    if (userCheckedResult) {
       resolve({ token: "far0fja*ff]afaawfqrlzkfq@aq9283af", ok: true, code: 200 });
     } else {
       reject({ ok: false, code: 401 });

--- a/lesson29/src/js/member.js
+++ b/lesson29/src/js/member.js
@@ -123,6 +123,8 @@ const togglePasswordButton = (e) => {
   }
 }
 
+const isEmailRegistered = (usersData) => Object.keys(usersData).some((key) => key === email.value);
+
 passwordButton.addEventListener("click", togglePasswordButton);
 password.addEventListener("blur", isValidField);
 email.addEventListener("blur", isValidField);
@@ -134,8 +136,18 @@ password.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
   e.preventDefault();
+  let usersData = JSON.parse(localStorage.getItem("morikenjuku"));
+  if (usersData && isEmailRegistered(usersData)) {
+    email.parentElement.classList.remove("valid");
+    addInvalidMessage(email, "既に登録されているメールアドレスです");
+    submitButton.disabled = "true";
+    return;
+  }
+  usersData = usersData ?? {};
   const inputValues = { username: userName.value, password: password.value, email: email.value };
-  localStorage.setItem("morikenjuku",JSON.stringify(inputValues));
+  usersData[email.value] = inputValues;
+  localStorage.setItem("morikenjuku", JSON.stringify(usersData));
+  
   const path = "./member-done.html";
   localStorage.setItem("registerDoneToken", "yayayayayayaooeoeore818181");
   window.location.href = `${path}?token=yayayayayayaooeoeore818181`;

--- a/lesson29/src/js/member.js
+++ b/lesson29/src/js/member.js
@@ -1,3 +1,5 @@
+import { Chance } from "chance";
+const chance = new Chance();
 const modalContent = document.getElementById("js-modal-content");
 const submitButton = document.getElementById("js-submit-button");
 const checkBox = document.querySelector(".js-check-box");

--- a/lesson29/src/js/member.js
+++ b/lesson29/src/js/member.js
@@ -5,9 +5,9 @@ const overLay = document.getElementById("js-overlay");
 const closeButton = document.getElementById("js-modal-close");
 const rules = document.getElementById("js-rules");
 const body = document.querySelector("body");
-const userName = document.getElementById("username");
-const email = document.getElementById("email");
-const password = document.getElementById("password");
+const userField = document.getElementById("username");
+const emailField = document.getElementById("email");
+const passwordField = document.getElementById("password");
 const passwordButton = document.getElementById("js-password-icon");
 
 
@@ -39,21 +39,21 @@ const constraint = {
   username: {
     validation: () => {
       const limitNumber = 16;
-      return isLimitTextLength(userName.value, limitNumber);
+      return isLimitTextLength(userField.value, limitNumber);
     },
     invalidMessage: "ユーザー名は15文字以下にしてください。"
   },
   email: {
     validation: () => {
       const reg = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+\.[A-Za-z]+(\.[A-Za-z]+?)?$/g;
-      return isInvalidRegex(reg, email.value);
+      return isInvalidRegex(reg, emailField.value);
     },
     invalidMessage: "メールアドレスの形式になっていません"
   },
   password: {
     validation: () => {
       const reg = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/g;
-      return isInvalidRegex(reg, password.value);
+      return isInvalidRegex(reg, passwordField.value);
     },
     invalidMessage: "8文字以上の大小の英数字を交ぜたものにしてください。"
   }
@@ -113,39 +113,39 @@ const toggleDisableSubmitButton = () => {
 const togglePasswordButton = (e) => {
   const target = e.target;
   if (target.classList.contains("is-hide")) {
-    password.type = "text";
+    passwordField.type = "text";
     target.classList.remove("is-hide");
     target.classList.add("is-show");
   } else {
-    password.type = "password";
+    passwordField.type = "password";
     target.classList.remove("is-show");
     target.classList.add("is-hide");
   }
 }
 
-const isEmailRegistered = (usersData) => Object.keys(usersData).some((key) => key === email.value);
+const isEmailRegistered = (usersData) => Object.keys(usersData).some((key) => key === emailField.value);
 
 passwordButton.addEventListener("click", togglePasswordButton);
-password.addEventListener("blur", isValidField);
-email.addEventListener("blur", isValidField);
-userName.addEventListener("blur", isValidField);
+passwordField.addEventListener("blur", isValidField);
+emailField.addEventListener("blur", isValidField);
+userField.addEventListener("blur", isValidField);
 checkBox.addEventListener("change", toggleDisableSubmitButton);
-userName.addEventListener("focus", resetInputField);
-email.addEventListener("focus", resetInputField);
-password.addEventListener("focus", resetInputField);
+userField.addEventListener("focus", resetInputField);
+emailField.addEventListener("focus", resetInputField);
+passwordField.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
   e.preventDefault();
   let usersData = JSON.parse(localStorage.getItem("morikenjuku"));
   if (usersData && isEmailRegistered(usersData)) {
     email.parentElement.classList.remove("valid");
-    addInvalidMessage(email, "既に登録されているメールアドレスです");
+    addInvalidMessage(emailField, "既に登録されているメールアドレスです");
     submitButton.disabled = "true";
     return;
   }
   usersData = usersData ?? {};
-  const inputValues = { username: userName.value, password: password.value, email: email.value };
-  usersData[email.value] = inputValues;
+  const inputValues = { username: userField.value, password: passwordField.value, email: emailField.value };
+  usersData[emailField.value] = inputValues;
   localStorage.setItem("morikenjuku", JSON.stringify(usersData));
   
   const path = "./member-done.html";

--- a/lesson29/src/js/member.js
+++ b/lesson29/src/js/member.js
@@ -10,7 +10,6 @@ const emailField = document.getElementById("email");
 const passwordField = document.getElementById("password");
 const passwordButton = document.getElementById("js-password-icon");
 
-
 const closeModal = () => {
   body.classList.remove("modal-open");
 };
@@ -127,16 +126,6 @@ const isEmailRegistered = (usersData) => {
   return Object.values(usersData).some(({ email }) => email === emailField.value);
 };
 
-const createRandomStr = () => {
-  const length = 8;
-  const source = "abcdefghijklmnopqrstuvwxyz0123456789";
-  let result = "";
-  for (let i = 0; i < length; i++) {
-    result += source[Math.floor(Math.random() * source.length)];
-  }
-  return result;
-}
-
 passwordButton.addEventListener("click", togglePasswordButton);
 passwordField.addEventListener("blur", isValidField);
 emailField.addEventListener("blur", isValidField);
@@ -156,12 +145,13 @@ submitButton.addEventListener("click", (e) => {
     return;
   }
   usersData = usersData ?? {};
-  const randomStr = createRandomStr();
-  const inputValues = { username: userField.value, password: passwordField.value, email: emailField.value, token: randomStr };
-  usersData[randomStr] = inputValues;
+  const userToken = chance.apple_token();
+  const inputValues = { username: userField.value, password: passwordField.value, email: emailField.value, token: userToken };
+  usersData[userToken] = inputValues;
   localStorage.setItem("morikenjuku", JSON.stringify(usersData));
 
   const path = "./member-done.html";
-  localStorage.setItem("registerDoneToken", "yayayayayayaooeoeore818181");
-  window.location.href = `${path}?token=yayayayayayaooeoeore818181`;
+  const registerDoneToken = chance.apple_token();
+  localStorage.setItem("registerDoneToken", registerDoneToken);
+  window.location.href = `${path}?token=${registerDoneToken}`;
 });

--- a/lesson29/src/js/member.js
+++ b/lesson29/src/js/member.js
@@ -123,7 +123,19 @@ const togglePasswordButton = (e) => {
   }
 }
 
-const isEmailRegistered = (usersData) => Object.keys(usersData).some((key) => key === emailField.value);
+const isEmailRegistered = (usersData) => {
+  return Object.values(usersData).some(({ email }) => email === emailField.value);
+};
+
+const createRandomStr = () => {
+  const length = 8;
+  const source = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    result += source[Math.floor(Math.random() * source.length)];
+  }
+  return result;
+}
 
 passwordButton.addEventListener("click", togglePasswordButton);
 passwordField.addEventListener("blur", isValidField);
@@ -138,16 +150,17 @@ submitButton.addEventListener("click", (e) => {
   e.preventDefault();
   let usersData = JSON.parse(localStorage.getItem("morikenjuku"));
   if (usersData && isEmailRegistered(usersData)) {
-    email.parentElement.classList.remove("valid");
+    emailField.parentElement.classList.remove("valid");
     addInvalidMessage(emailField, "既に登録されているメールアドレスです");
     submitButton.disabled = "true";
     return;
   }
   usersData = usersData ?? {};
-  const inputValues = { username: userField.value, password: passwordField.value, email: emailField.value };
-  usersData[emailField.value] = inputValues;
+  const randomStr = createRandomStr();
+  const inputValues = { username: userField.value, password: passwordField.value, email: emailField.value, token: randomStr };
+  usersData[randomStr] = inputValues;
   localStorage.setItem("morikenjuku", JSON.stringify(usersData));
-  
+
   const path = "./member-done.html";
   localStorage.setItem("registerDoneToken", "yayayayayayaooeoeore818181");
   window.location.href = `${path}?token=yayayayayayaooeoeore818181`;

--- a/lesson29/src/js/resetingemail.js
+++ b/lesson29/src/js/resetingemail.js
@@ -90,6 +90,8 @@ const togglePasswordButton = (e) => {
   }
 }
 
+const isUserPassword = (data) => data[localStorage.getItem("token")].password === passwordField.value;
+
 passwordButton.addEventListener("click", togglePasswordButton);
 passwordField.addEventListener("blur", isValidField);
 emailField.addEventListener("blur", isValidField);
@@ -101,11 +103,9 @@ passwordField.addEventListener("focus", resetInputField);
 changeButton.addEventListener("click", (e) => {
   e.preventDefault();
   const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
-  const matchedUserData = Object.values(usersData).find(
-    (data) => data.password === passwordField.value
-  );
-  if (matchedUserData) {
-    matchedUserData.email = emailField.value;
+  const loginToken = localStorage.getItem("token");
+  if (isUserPassword(usersData)) {
+    usersData[loginToken].email = emailField.value;
     localStorage.setItem("morikenjuku", JSON.stringify(usersData));
     window.location.href = `./resetmaildone.html?token=${localStorage.token}`;
   } else {

--- a/lesson29/src/js/resetingemail.js
+++ b/lesson29/src/js/resetingemail.js
@@ -1,21 +1,21 @@
-const email = document.getElementById("email");
-const confirmEmail = document.getElementById("confirmEmail");
+const emailField = document.getElementById("email");
+const confirmEmailField = document.getElementById("confirmEmail");
 const changeButton = document.getElementById("js-submit-button");
 const passwordButton = document.getElementById("js-password-icon");
-const password = document.getElementById("password");
+const passwordField = document.getElementById("password");
 
 const constraint = {
   email: {
     validation: () => {
       const reg = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+\.[A-Za-z]+(\.[A-Za-z]+?)?$/g;
-      return isInvalidRegex(reg, email.value);
+      return isInvalidRegex(reg, emailField.value);
     },
     invalidMessage: "メールアドレスの形式になっていません"
   },
   confirmEmail: {
     validation: () => {
-      const confirmTrimmedValue = confirmEmail.value.trim();
-      const emailTrimmedValue = email.value.trim();
+      const confirmTrimmedValue = confirmEmailField.value.trim();
+      const emailTrimmedValue = emailField.value.trim();
       return confirmTrimmedValue !== emailTrimmedValue;
     },
     invalidMessage: "入力されたメールアドレスが一致してません"
@@ -23,7 +23,7 @@ const constraint = {
   password: {
     validation: () => {
       const reg = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/g;
-      return isInvalidRegex(reg, password.value);
+      return isInvalidRegex(reg, passwordField.value);
     },
     invalidMessage: "8文字以上の大小の英数字を交ぜたものにしてください。"
   }
@@ -80,35 +80,35 @@ const toggleDisableChangeButton = () => {
 const togglePasswordButton = (e) => {
   const target = e.target;
   if (target.classList.contains("is-hide")) {
-    password.type = "text";
+    passwordField.type = "text";
     target.classList.remove("is-hide");
     target.classList.add("is-show");
   } else {
-    password.type = "password";
+    passwordField.type = "password";
     target.classList.remove("is-show");
     target.classList.add("is-hide");
   }
 }
 
 passwordButton.addEventListener("click", togglePasswordButton);
-password.addEventListener("blur", isValidField);
-email.addEventListener("blur", isValidField);
-email.addEventListener("focus", resetInputField);
-confirmEmail.addEventListener("blur", isValidField);
-confirmEmail.addEventListener("focus", resetInputField);
-password.addEventListener("focus", resetInputField);
+passwordField.addEventListener("blur", isValidField);
+emailField.addEventListener("blur", isValidField);
+emailField.addEventListener("focus", resetInputField);
+confirmEmailField.addEventListener("blur", isValidField);
+confirmEmailField.addEventListener("focus", resetInputField);
+passwordField.addEventListener("focus", resetInputField);
 
 changeButton.addEventListener("click", (e) => {
   e.preventDefault();
   const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
-  const matchedUserData = Object.values(usersData).find((data) => data.password === password.value);
+  const matchedUserData = Object.values(usersData).find((data) => data.password === passwordField.value);
   if (matchedUserData) {
-    matchedUserData.email = email.value;
+    matchedUserData.email = emailField.value;
     localStorage.setItem("morikenjuku", JSON.stringify(usersData));
     window.location.href = `./resetmaildone.html?token=${localStorage.token}`;
   } else {
-    password.parentElement.classList.remove("valid");
+    passwordField.parentElement.classList.remove("valid");
     changeButton.disabled = true;
-    addInvalidMessage(password, "パスワードが正しくありません");
+    addInvalidMessage(passwordField, "パスワードが正しくありません");
   }
 });

--- a/lesson29/src/js/resetingemail.js
+++ b/lesson29/src/js/resetingemail.js
@@ -101,7 +101,9 @@ passwordField.addEventListener("focus", resetInputField);
 changeButton.addEventListener("click", (e) => {
   e.preventDefault();
   const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
-  const matchedUserData = Object.values(usersData).find((data) => data.password === passwordField.value);
+  const matchedUserData = Object.values(usersData).find(
+    (data) => data.password === passwordField.value
+  );
   if (matchedUserData) {
     matchedUserData.email = emailField.value;
     localStorage.setItem("morikenjuku", JSON.stringify(usersData));

--- a/lesson29/src/js/resetingemail.js
+++ b/lesson29/src/js/resetingemail.js
@@ -90,11 +90,6 @@ const togglePasswordButton = (e) => {
   }
 }
 
-const changeUserEmail = (userData) => {
-  userData.email = email.value;
-  localStorage.setItem("morikenjuku",JSON.stringify(userData));
-}
-
 passwordButton.addEventListener("click", togglePasswordButton);
 password.addEventListener("blur", isValidField);
 email.addEventListener("blur", isValidField);
@@ -103,15 +98,17 @@ confirmEmail.addEventListener("blur", isValidField);
 confirmEmail.addEventListener("focus", resetInputField);
 password.addEventListener("focus", resetInputField);
 
-changeButton.addEventListener("click",(e) => {
+changeButton.addEventListener("click", (e) => {
   e.preventDefault();
-  const userData = JSON.parse(localStorage.getItem("morikenjuku"));
-  if(password.value === userData.password) {
-    changeUserEmail(userData);
+  const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
+  const matchedUserData = Object.values(usersData).find((data) => data.password === password.value);
+  if (matchedUserData) {
+    matchedUserData.email = email.value;
+    localStorage.setItem("morikenjuku", JSON.stringify(usersData));
     window.location.href = `./resetmaildone.html?token=${localStorage.token}`;
   } else {
     password.parentElement.classList.remove("valid");
     changeButton.disabled = true;
-    addInvalidMessage(password,"パスワードが正しくありません");
+    addInvalidMessage(password, "パスワードが正しくありません");
   }
 });

--- a/lesson29/src/js/resetingpassword.js
+++ b/lesson29/src/js/resetingpassword.js
@@ -1,28 +1,28 @@
 const passwordButtons = [...document.querySelectorAll(".js-password-icon")];
-const confirmNewPassword = document.getElementById("confirmNewPassword");
-const newPassword = document.getElementById("newPassword");
-const password = document.getElementById("password");
+const confirmPasswordField = document.getElementById("confirmNewPassword");
+const newPasswordField = document.getElementById("newPassword");
+const passwordField = document.getElementById("password");
 const changeButton = document.getElementById("js-change-button");
 
 const constraint = {
   password: {
     validation: () => {
       const reg = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/g;
-      return !reg.test(password.value);
+      return !reg.test(passwordField.value);
     },
     invalidMessage: "8文字以上の大小の英数字を交ぜたものにしてください。"
   },
   newPassword: {
     validation: () => {
       const reg = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])[a-zA-Z0-9]{8,}$/g;
-      return !reg.test(newPassword.value);
+      return !reg.test(newPasswordField.value);
     },
     invalidMessage: "8文字以上の大小の英数字を交ぜたものにしてください。"
   },
   confirmNewPassword: {
     validation: () => {
-      const confirmTrimmedValue = confirmNewPassword.value.trim();
-      const passwordTrimmedValue = newPassword.value.trim();
+      const confirmTrimmedValue = confirmPasswordField.value.trim();
+      const passwordTrimmedValue = newPasswordField.value.trim();
       return confirmTrimmedValue !== passwordTrimmedValue;
     },
     invalidMessage: "入力されたパスワードが一致してません"
@@ -91,24 +91,24 @@ const togglePasswordButton = (e) => {
 passwordButtons.forEach((button) => {
   button.addEventListener("click", togglePasswordButton);
 });
-password.addEventListener("blur", isValidField);
-newPassword.addEventListener("blur", isValidField);
-confirmNewPassword.addEventListener("blur", isValidField);
-newPassword.addEventListener("focus", resetInputField);
-confirmNewPassword.addEventListener("focus", resetInputField);
-password.addEventListener("focus", resetInputField);
+passwordField.addEventListener("blur", isValidField);
+newPasswordField.addEventListener("blur", isValidField);
+confirmPasswordField.addEventListener("blur", isValidField);
+newPasswordField.addEventListener("focus", resetInputField);
+confirmPasswordField.addEventListener("focus", resetInputField);
+passwordField.addEventListener("focus", resetInputField);
 
 changeButton.addEventListener("click", (e) => {
   e.preventDefault();
   const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
-  const matchedUserData = Object.values(usersData).find((data) => data.password === password.value);
+  const matchedUserData = Object.values(usersData).find((data) => data.password === passwordField.value);
   if (matchedUserData) {
-    matchedUserData.password = newPassword.value;
+    matchedUserData.password = newPasswordField.value;
     localStorage.setItem("morikenjuku", JSON.stringify(usersData));
     window.location.href = `./resetpassworddone.html?token=${localStorage.token}`;
   } else {
-    password.parentElement.classList.remove("valid");
+    passwordField.parentElement.classList.remove("valid");
     changeButton.disabled = true;
-    addInvalidMessage(password, "パスワードが正しくありません");
+    addInvalidMessage(passwordField, "パスワードが正しくありません");
   }
 });

--- a/lesson29/src/js/resetingpassword.js
+++ b/lesson29/src/js/resetingpassword.js
@@ -88,6 +88,9 @@ const togglePasswordButton = (e) => {
   }
 };
 
+const isUserPassword = (data) => data[localStorage.getItem("token")].password === passwordField.value;
+
+
 passwordButtons.forEach((button) => {
   button.addEventListener("click", togglePasswordButton);
 });
@@ -101,9 +104,9 @@ passwordField.addEventListener("focus", resetInputField);
 changeButton.addEventListener("click", (e) => {
   e.preventDefault();
   const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
-  const matchedUserData = Object.values(usersData).find((data) => data.password === passwordField.value);
-  if (matchedUserData) {
-    matchedUserData.password = newPasswordField.value;
+  const loginToken = localStorage.getItem("token");
+  if (isUserPassword(usersData)) {
+    usersData[loginToken].password = newPasswordField.value;
     localStorage.setItem("morikenjuku", JSON.stringify(usersData));
     window.location.href = `./resetpassworddone.html?token=${localStorage.token}`;
   } else {

--- a/lesson29/src/js/resetingpassword.js
+++ b/lesson29/src/js/resetingpassword.js
@@ -90,7 +90,6 @@ const togglePasswordButton = (e) => {
 
 const isUserPassword = (data) => data[localStorage.getItem("token")].password === passwordField.value;
 
-
 passwordButtons.forEach((button) => {
   button.addEventListener("click", togglePasswordButton);
 });

--- a/lesson29/src/js/resetingpassword.js
+++ b/lesson29/src/js/resetingpassword.js
@@ -88,11 +88,6 @@ const togglePasswordButton = (e) => {
   }
 };
 
-const changeUserPassword = (userData) => {
-  userData.password = newPassword.value;
-  localStorage.setItem("morikenjuku", JSON.stringify(userData));
-};
-
 passwordButtons.forEach((button) => {
   button.addEventListener("click", togglePasswordButton);
 });
@@ -105,9 +100,11 @@ password.addEventListener("focus", resetInputField);
 
 changeButton.addEventListener("click", (e) => {
   e.preventDefault();
-  const userData = JSON.parse(localStorage.getItem("morikenjuku"));
-  if (password.value === userData.password) {
-    changeUserPassword(userData);
+  const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
+  const matchedUserData = Object.values(usersData).find((data) => data.password === password.value);
+  if (matchedUserData) {
+    matchedUserData.password = newPassword.value;
+    localStorage.setItem("morikenjuku", JSON.stringify(usersData));
     window.location.href = `./resetpassworddone.html?token=${localStorage.token}`;
   } else {
     password.parentElement.classList.remove("valid");

--- a/lesson29/src/register/member.html
+++ b/lesson29/src/register/member.html
@@ -7,8 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="../css/reset.css" />
   <link rel="stylesheet" href="../css/style.css" />
-  <script src="../js/chance.min.js" defer></script>
-  <script src="../js/member.js" defer></script>
+  <script src="../js/member.js" type="module" defer></script>
   <title>Document</title>
 </head>
 

--- a/lesson29/src/register/member.html
+++ b/lesson29/src/register/member.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="../css/reset.css" />
   <link rel="stylesheet" href="../css/style.css" />
+  <script src="../js/chance.min.js" defer></script>
   <script src="../js/member.js" defer></script>
   <title>Document</title>
 </head>


### PR DESCRIPTION
# [Lesson29](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#29)
## [codesandbox](https://codesandbox.io/s/lesson29-vlghhg?file=/register/member.html) / d8190c9
## 追加・修正した点
- 同じメールアドレスでの会員登録を防止
- 複数会員登録を可能に
- localstorage内で管理するuser情報を以下のように~メールアドレス~tokenをkeyとしたオブジェクトに変更
``` js
{
hoadjkdjdju919: {username: "satou", password: "KOKOKOko19191", email: "jajajja@te.com",token:hoadjkdjdju919},
jeyyeyolalamaa: {username: "itou", password: "sasasasasaSA11111", email: "sajajaj@eyyey.com",token:jeyyeyolalamaa},
testisiskkslsaaa: {username: "yamada", password: "hogehogeHOge1111", email: "test@test.com",token:testisiskkslsaaa},
}
```
- 発行するtokenは[Chance](https://chancejs.com/index.html)ライブラリーを使用して実装
- ログイン時はログインユーザーのtokenを以下のようにlocalstorageにsetし、ログイン中のユーザが判断できるようにする
``` js
token: hoadjkdjdju919
```