### PR TITLE
refactor: fix of forgot password page due to specification change

### DIFF
--- a/lesson29/src/js/forgotpassword.js
+++ b/lesson29/src/js/forgotpassword.js
@@ -42,15 +42,22 @@ const emailValidation = (e) => {
   submitButton.disabled = false;
 };
 
+const findUserEmailMatch = (usersData) => {
+  return Object.values(usersData).find(({ email }) => email === emailField.value);
+}
+
 emailField.addEventListener("blur", emailValidation);
 emailField.addEventListener("focus", resetInputField);
 
 submitButton.addEventListener("click", (e) => {
   e.preventDefault();
-  if(localStorage.getItem("morikenjuku")) {
+  const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
+  const matchedUserData = findUserEmailMatch(usersData);
+  if (matchedUserData) {
+    const userToken = matchedUserData.token;
     const path = "../register/password.html";
-    localStorage.setItem("resetPasswordToken","482r22fafah");
-    window.location.href = `${path}?token=482r22fafah`;
+    localStorage.setItem("resetPasswordToken", userToken);
+    window.location.href = `${path}?token=${userToken}`;
   } else {
     window.location.href = "../notregistereduser.html";
   }

--- a/lesson29/src/js/password.js
+++ b/lesson29/src/js/password.js
@@ -2,6 +2,8 @@ const passwordButtons = [...document.querySelectorAll(".js-password-icon")];
 const submitButton = document.getElementById("js-submit-button");
 const passwordField = document.getElementById("password");
 const confirmPasswordField = document.getElementById("confirmPassword");
+import { Chance } from "chance";
+const chance = new Chance()
 
 const constraint = {
   password: {
@@ -102,17 +104,19 @@ passwordField.addEventListener("focus", resetInputField);
 confirmPasswordField.addEventListener("blur", isValidField);
 confirmPasswordField.addEventListener("focus", resetInputField);
 
-const changeUserPasswordInStorage = () => {
-  const userData = JSON.parse(localStorage.morikenjuku);
-  userData.password = passwordField.value;
-  localStorage.setItem("morikenjuku", JSON.stringify(userData));
+const changeUserPassword = () => {
+  const usersData = JSON.parse(localStorage.getItem("morikenjuku"));
+  const token = localStorage.getItem("resetPasswordToken");
+  usersData[token].password = passwordField.value;
+  localStorage.setItem("morikenjuku", JSON.stringify(usersData));
 }
 
 submitButton.addEventListener("click", (e) => {
   e.preventDefault();
-  changeUserPasswordInStorage();
+  changeUserPassword();
   localStorage.removeItem("resetPasswordToken");
-  localStorage.setItem("forgotPasswordDoneToken", "hoge123aaaa");
+  const forgotPasswordDoneToken = chance.apple_token();
+  localStorage.setItem("forgotPasswordDoneToken", forgotPasswordDoneToken);
   const path = "./password-done.html";
-  window.location.href = `${path}?token=hoge123aaaa`;
+  window.location.href = `${path}?token=${forgotPasswordDoneToken}`;
 });

--- a/lesson29/src/register/password.html
+++ b/lesson29/src/register/password.html
@@ -8,7 +8,7 @@
   <title>Document</title>
   <link rel="stylesheet" href="../css/reset.css" />
   <link rel="stylesheet" href="../css/style.css" />
-  <script src="../js/password.js" defer></script>
+  <script src="../js/password.js" type="module"></script>
 </head>
 
 <body>


### PR DESCRIPTION
# [Lesson29](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#29)
## [codesandbox](https://codesandbox.io/s/lesson29-vlghhg?file=/js/forgotpassword.js) / 9f8b142

## 仕様の追加・変更箇所
- 同じメールアドレスでの会員登録を防止
- 複数会員登録を可能に
- 発行するtokenは[Chance](https://chancejs.com/index.html)ライブラリーを使用して実装
- localstorage内で管理するuser情報を以下のように tokenをkeyとしたオブジェクトに変更
``` js
{
hoadjkdjdju919: {username: "satou", password: "KOKOKOko19191", email: "jajajja@te.com",token:hoadjkdjdju919},
jeyyeyolalamaa: {username: "itou", password: "sasasasasaSA11111", email: "sajajaj@eyyey.com",token:jeyyeyolalamaa},
testisiskkslsaaa: {username: "yamada", password: "hogehogeHOge1111", email: "test@test.com",token:testisiskkslsaaa},
}
```
## PR箇所
- パスワードを忘れた方ページ(`forgotpassword.html`)で入力されたメールアドレスと一致するuserがいるかlocalstorage内を確認する
(いなければ`notregistereduser.html`へ)
- 上で一致するuserがいれば、対象userのtokenを取得しlocalstorageへ追加。urlパラメータに追加し遷移
-  password再設定ページで新たなパスワードを入力後、上で追加したtokenをキーとしてuserのpasswordを変更
- 新たにtokenを発行し、完了ページへ遷移(上で発行したtokenは削除)

## イメージ図
<img src ="https://i.postimg.cc/50QPhtDv/Frame-6.jpg">
